### PR TITLE
When using RabbitMQ, the virtualHost API call was ignored.

### DIFF
--- a/protonj2-client/src/main/java/org/apache/qpid/protonj2/client/ConnectionOptions.java
+++ b/protonj2-client/src/main/java/org/apache/qpid/protonj2/client/ConnectionOptions.java
@@ -130,6 +130,7 @@ public class ConnectionOptions implements Cloneable {
         other.reconnectedHandler(reconnectedHandler);
         other.disconnectedHandler(disconnectedHandler);
         other.defaultNextReceiverPolicy(nextReceiverPolicy);
+        other.virtualHost(virtualHost);
 
         if (offeredCapabilities != null) {
             other.offeredCapabilities(Arrays.copyOf(offeredCapabilities, offeredCapabilities.length));

--- a/protonj2-client/src/main/java/org/apache/qpid/protonj2/client/impl/ClientConnection.java
+++ b/protonj2-client/src/main/java/org/apache/qpid/protonj2/client/impl/ClientConnection.java
@@ -886,10 +886,11 @@ public final class ClientConnection implements Connection {
             protonConnection.setContainerId(connectionId);
         }
 
+        final String hostname = (options.virtualHost() == null || options.virtualHost().length() < 1) ? location.getHost() : options.virtualHost();
         protonConnection.setLinkedResource(this);
         protonConnection.setChannelMax(options.channelMax());
         protonConnection.setMaxFrameSize(options.maxFrameSize());
-        protonConnection.setHostname(location.getHost());
+        protonConnection.setHostname(hostname);
         protonConnection.setIdleTimeout((int) options.idleTimeout());
         protonConnection.setOfferedCapabilities(ClientConversionSupport.toSymbolArray(options.offeredCapabilities()));
         protonConnection.setDesiredCapabilities(ClientConversionSupport.toSymbolArray(options.desiredCapabilities()));

--- a/protonj2-client/src/main/java/org/apache/qpid/protonj2/client/impl/ClientConnection.java
+++ b/protonj2-client/src/main/java/org/apache/qpid/protonj2/client/impl/ClientConnection.java
@@ -886,7 +886,7 @@ public final class ClientConnection implements Connection {
             protonConnection.setContainerId(connectionId);
         }
 
-        final String hostname = (options.virtualHost() == null || options.virtualHost().length() < 1) ? location.getHost() : options.virtualHost();
+        final String hostname = (options.virtualHost() == null || options.virtualHost().isEmpty()) ? location.getHost() : options.virtualHost();
         protonConnection.setLinkedResource(this);
         protonConnection.setChannelMax(options.channelMax());
         protonConnection.setMaxFrameSize(options.maxFrameSize());


### PR DESCRIPTION
When using RabbitMQ, the virtualHost API call was ignored. The virtualHost settings were ignored when set in ConnectionOptions.