### PR TITLE
Set echo value if necessary in outgoing flow

### DIFF
--- a/protonj2/src/main/java/org/apache/qpid/protonj2/engine/impl/ProtonLinkCreditState.java
+++ b/protonj2/src/main/java/org/apache/qpid/protonj2/engine/impl/ProtonLinkCreditState.java
@@ -120,6 +120,10 @@ public class ProtonLinkCreditState implements LinkCreditState {
         this.deliveryCount = deliveryCount;
     }
 
+    public void updateEcho(boolean echo) {
+        this.echo = echo;
+    }
+
     void remoteFlow(Flow flow) {
         remoteDeliveryCount = flow.getDeliveryCount();
         remoteLinkCredit = flow.getLinkCredit();

--- a/protonj2/src/main/java/org/apache/qpid/protonj2/engine/impl/ProtonReceiver.java
+++ b/protonj2/src/main/java/org/apache/qpid/protonj2/engine/impl/ProtonReceiver.java
@@ -446,6 +446,9 @@ public class ProtonReceiver extends ProtonLink<Receiver> implements Receiver {
             flow.setDeliveryCount(getCreditState().getDeliveryCount());
         }
         flow.setDrain(isDraining());
+        if (getCreditState().isEcho()) {
+            flow.setEcho(true);
+        }
 
         return this;
     }


### PR DESCRIPTION
Setting echo to true can be used to stop gracefully a receiver link before detaching it or just pausing it (see 2.6.10 of spec).